### PR TITLE
[Refator] 퀴즈 화면에 있던 진행도 표시 UI를 다른 테이블뷰에서도 사용할 수 있도록 변경

### DIFF
--- a/oewoboka/oewoboka.xcodeproj/project.pbxproj
+++ b/oewoboka/oewoboka.xcodeproj/project.pbxproj
@@ -18,6 +18,12 @@
 		18E0D2172AC133A2005DDA6F /* FeatureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2162AC133A2005DDA6F /* FeatureViewController.swift */; };
 		18E0D2192AC133AD005DDA6F /* VocaListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2182AC133AD005DDA6F /* VocaListViewController.swift */; };
 		18E0D21B2AC133FE005DDA6F /* AddVocabularyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D21A2AC133FE005DDA6F /* AddVocabularyViewController.swift */; };
+		18E0D21E2AC17E94005DDA6F /* Vocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D21D2AC17E94005DDA6F /* Vocabulary.swift */; };
+		18E0D2202AC17ED7005DDA6F /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D21F2AC17ED7005DDA6F /* Word.swift */; };
+		18E0D2232AC181CB005DDA6F /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2222AC181CB005DDA6F /* CardView.swift */; };
+		18E0D2252AC18B90005DDA6F /* QuizControlStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2242AC18B90005DDA6F /* QuizControlStackView.swift */; };
+		18E0D2282AC1930F005DDA6F /* QuizCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2272AC1930F005DDA6F /* QuizCompleteViewController.swift */; };
+		18E0D22B2AC19344005DDA6F /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D22A2AC19344005DDA6F /* ResultView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +39,12 @@
 		18E0D2162AC133A2005DDA6F /* FeatureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureViewController.swift; sourceTree = "<group>"; };
 		18E0D2182AC133AD005DDA6F /* VocaListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocaListViewController.swift; sourceTree = "<group>"; };
 		18E0D21A2AC133FE005DDA6F /* AddVocabularyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddVocabularyViewController.swift; sourceTree = "<group>"; };
+		18E0D21D2AC17E94005DDA6F /* Vocabulary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vocabulary.swift; sourceTree = "<group>"; };
+		18E0D21F2AC17ED7005DDA6F /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
+		18E0D2222AC181CB005DDA6F /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		18E0D2242AC18B90005DDA6F /* QuizControlStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizControlStackView.swift; sourceTree = "<group>"; };
+		18E0D2272AC1930F005DDA6F /* QuizCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizCompleteViewController.swift; sourceTree = "<group>"; };
+		18E0D22A2AC19344005DDA6F /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +91,7 @@
 			isa = PBXGroup;
 			children = (
 				18E0D1F42AC1305D005DDA6F /* TabBarController.swift */,
+				18E0D2262AC192EC005DDA6F /* QuizCompletePage */,
 				18E0D2112AC1336A005DDA6F /* QuizPage */,
 				18E0D2102AC13322005DDA6F /* AddVocabularyPage */,
 				18E0D20F2AC1330A005DDA6F /* FeaturePage */,
@@ -148,9 +161,46 @@
 		18E0D2112AC1336A005DDA6F /* QuizPage */ = {
 			isa = PBXGroup;
 			children = (
+				18E0D2212AC17FF9005DDA6F /* View */,
+				18E0D21C2AC17E43005DDA6F /* Model */,
 				18E0D2122AC13388005DDA6F /* QuizViewController.swift */,
 			);
 			path = QuizPage;
+			sourceTree = "<group>";
+		};
+		18E0D21C2AC17E43005DDA6F /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				18E0D21D2AC17E94005DDA6F /* Vocabulary.swift */,
+				18E0D21F2AC17ED7005DDA6F /* Word.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		18E0D2212AC17FF9005DDA6F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				18E0D2222AC181CB005DDA6F /* CardView.swift */,
+				18E0D2242AC18B90005DDA6F /* QuizControlStackView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		18E0D2262AC192EC005DDA6F /* QuizCompletePage */ = {
+			isa = PBXGroup;
+			children = (
+				18E0D2292AC1932F005DDA6F /* View */,
+				18E0D2272AC1930F005DDA6F /* QuizCompleteViewController.swift */,
+			);
+			path = QuizCompletePage;
+			sourceTree = "<group>";
+		};
+		18E0D2292AC1932F005DDA6F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				18E0D22A2AC19344005DDA6F /* ResultView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -230,12 +280,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				18E0D2172AC133A2005DDA6F /* FeatureViewController.swift in Sources */,
+				18E0D2282AC1930F005DDA6F /* QuizCompleteViewController.swift in Sources */,
 				18E0D20D2AC13264005DDA6F /* AddVocaViewController.swift in Sources */,
 				18E0D2192AC133AD005DDA6F /* VocaListViewController.swift in Sources */,
 				18E0D2132AC13388005DDA6F /* QuizViewController.swift in Sources */,
+				18E0D22B2AC19344005DDA6F /* ResultView.swift in Sources */,
+				18E0D21E2AC17E94005DDA6F /* Vocabulary.swift in Sources */,
 				18E0D21B2AC133FE005DDA6F /* AddVocabularyViewController.swift in Sources */,
 				18E0D1F52AC1305D005DDA6F /* TabBarController.swift in Sources */,
+				18E0D2202AC17ED7005DDA6F /* Word.swift in Sources */,
+				18E0D2252AC18B90005DDA6F /* QuizControlStackView.swift in Sources */,
 				18E0D1F12AC1305D005DDA6F /* AppDelegate.swift in Sources */,
+				18E0D2232AC181CB005DDA6F /* CardView.swift in Sources */,
 				18E0D1F32AC1305D005DDA6F /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/oewoboka/oewoboka.xcodeproj/project.pbxproj
+++ b/oewoboka/oewoboka.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		18B97AF42AC3C819006C0AAA /* QuizResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B97AF32AC3C819006C0AAA /* QuizResultType.swift */; };
 		18BF668A2AC208B300C53C07 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF66892AC208B300C53C07 /* Typography.swift */; };
 		18BF668D2AC2097400C53C07 /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF668C2AC2097400C53C07 /* DefaultButton.swift */; };
+		18C3457F2ACA638C0072995F /* TopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C3457E2ACA638C0072995F /* TopView.swift */; };
+		18C345812ACA67F90072995F /* BottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C345802ACA67F90072995F /* BottomView.swift */; };
+		18C345842ACA6CB30072995F /* AnswerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C345832ACA6CB30072995F /* AnswerTableViewCell.swift */; };
+		18CE95B22AC6D84900CAA133 /* BottomSheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE95B12AC6D84900CAA133 /* BottomSheetPresentationController.swift */; };
+		18CE95B42AC6DAF400CAA133 /* AnswerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE95B32AC6DAF400CAA133 /* AnswerViewController.swift */; };
 		18CE9BE72AC2CA9900D39403 /* FeedBackStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */; };
 		18E0D1F12AC1305D005DDA6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D1F02AC1305D005DDA6F /* AppDelegate.swift */; };
 		18E0D1F32AC1305D005DDA6F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D1F22AC1305D005DDA6F /* SceneDelegate.swift */; };
@@ -44,6 +49,11 @@
 		18B97AF32AC3C819006C0AAA /* QuizResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultType.swift; sourceTree = "<group>"; };
 		18BF66892AC208B300C53C07 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		18BF668C2AC2097400C53C07 /* DefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultButton.swift; sourceTree = "<group>"; };
+		18C3457E2ACA638C0072995F /* TopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopView.swift; sourceTree = "<group>"; };
+		18C345802ACA67F90072995F /* BottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomView.swift; sourceTree = "<group>"; };
+		18C345832ACA6CB30072995F /* AnswerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerTableViewCell.swift; sourceTree = "<group>"; };
+		18CE95B12AC6D84900CAA133 /* BottomSheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresentationController.swift; sourceTree = "<group>"; };
+		18CE95B32AC6DAF400CAA133 /* AnswerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerViewController.swift; sourceTree = "<group>"; };
 		18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedBackStackView.swift; sourceTree = "<group>"; };
 		18E0D1ED2AC1305D005DDA6F /* oewoboka.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = oewoboka.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		18E0D1F02AC1305D005DDA6F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -118,6 +128,34 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		18C3457C2ACA5AD10072995F /* AnswerPage */ = {
+			isa = PBXGroup;
+			children = (
+				18C345822ACA6CA10072995F /* Cell */,
+				18C3457D2ACA5AEF0072995F /* View */,
+				18CE95B12AC6D84900CAA133 /* BottomSheetPresentationController.swift */,
+				18CE95B32AC6DAF400CAA133 /* AnswerViewController.swift */,
+			);
+			path = AnswerPage;
+			sourceTree = "<group>";
+		};
+		18C3457D2ACA5AEF0072995F /* View */ = {
+			isa = PBXGroup;
+			children = (
+				18C3457E2ACA638C0072995F /* TopView.swift */,
+				18C345802ACA67F90072995F /* BottomView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		18C345822ACA6CA10072995F /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				18C345832ACA6CB30072995F /* AnswerTableViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 		18E0D1E42AC1305D005DDA6F = {
 			isa = PBXGroup;
 			children = (
@@ -154,6 +192,7 @@
 			isa = PBXGroup;
 			children = (
 				18E0D1F42AC1305D005DDA6F /* TabBarController.swift */,
+				18C3457C2ACA5AD10072995F /* AnswerPage */,
 				18E0D2262AC192EC005DDA6F /* QuizCompletePage */,
 				18E0D2112AC1336A005DDA6F /* QuizPage */,
 				18E0D2102AC13322005DDA6F /* AddVocabularyPage */,
@@ -346,6 +385,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18C3457F2ACA638C0072995F /* TopView.swift in Sources */,
 				18E0D2172AC133A2005DDA6F /* FeatureViewController.swift in Sources */,
 				18E0D2282AC1930F005DDA6F /* QuizCompleteViewController.swift in Sources */,
 				084C45ED2AC1943E002999DF /* FeatureCollectionViewCell.swift in Sources */,
@@ -354,6 +394,8 @@
 				084C45F22AC1A9CB002999DF /* FeatureCellModels.swift in Sources */,
 				18E0D20D2AC13264005DDA6F /* AddVocaViewController.swift in Sources */,
 				18E0D2192AC133AD005DDA6F /* VocaListViewController.swift in Sources */,
+				18C345812ACA67F90072995F /* BottomView.swift in Sources */,
+				18CE95B22AC6D84900CAA133 /* BottomSheetPresentationController.swift in Sources */,
 				18BF668A2AC208B300C53C07 /* Typography.swift in Sources */,
 				18E0D2132AC13388005DDA6F /* QuizViewController.swift in Sources */,
 				18E0D22B2AC19344005DDA6F /* ResultView.swift in Sources */,
@@ -362,9 +404,11 @@
 				18E0D1F52AC1305D005DDA6F /* TabBarController.swift in Sources */,
 				18E0D2202AC17ED7005DDA6F /* Word.swift in Sources */,
 				18E0D2252AC18B90005DDA6F /* QuizControlStackView.swift in Sources */,
+				18CE95B42AC6DAF400CAA133 /* AnswerViewController.swift in Sources */,
 				18A815BA2AC3E1D3007FE489 /* QuizType.swift in Sources */,
 				18E0D1F12AC1305D005DDA6F /* AppDelegate.swift in Sources */,
 				18E0D2232AC181CB005DDA6F /* CardView.swift in Sources */,
+				18C345842ACA6CB30072995F /* AnswerTableViewCell.swift in Sources */,
 				18E0D1F32AC1305D005DDA6F /* SceneDelegate.swift in Sources */,
 				18CE9BE72AC2CA9900D39403 /* FeedBackStackView.swift in Sources */,
 				084C45F52AC1A9FA002999DF /* Constant.swift in Sources */,
@@ -509,6 +553,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2FY7M8J988;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = oewoboka/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -534,8 +579,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2FY7M8J988;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = oewoboka/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -550,6 +597,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = KD.oewoboka;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/oewoboka/oewoboka.xcodeproj/project.pbxproj
+++ b/oewoboka/oewoboka.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		084C45ED2AC1943E002999DF /* FeatureCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084C45EC2AC1943E002999DF /* FeatureCollectionViewCell.swift */; };
 		084C45F22AC1A9CB002999DF /* FeatureCellModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084C45F12AC1A9CB002999DF /* FeatureCellModels.swift */; };
 		084C45F52AC1A9FA002999DF /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084C45F42AC1A9FA002999DF /* Constant.swift */; };
+		18A815BA2AC3E1D3007FE489 /* QuizType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A815B92AC3E1D3007FE489 /* QuizType.swift */; };
+		18B97AF42AC3C819006C0AAA /* QuizResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B97AF32AC3C819006C0AAA /* QuizResultType.swift */; };
 		18BF668A2AC208B300C53C07 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF66892AC208B300C53C07 /* Typography.swift */; };
 		18BF668D2AC2097400C53C07 /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF668C2AC2097400C53C07 /* DefaultButton.swift */; };
 		18CE9BE72AC2CA9900D39403 /* FeedBackStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */; };
@@ -38,6 +40,8 @@
 		084C45EC2AC1943E002999DF /* FeatureCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureCollectionViewCell.swift; sourceTree = "<group>"; };
 		084C45F12AC1A9CB002999DF /* FeatureCellModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureCellModels.swift; sourceTree = "<group>"; };
 		084C45F42AC1A9FA002999DF /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
+		18A815B92AC3E1D3007FE489 /* QuizType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizType.swift; sourceTree = "<group>"; };
+		18B97AF32AC3C819006C0AAA /* QuizResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizResultType.swift; sourceTree = "<group>"; };
 		18BF66892AC208B300C53C07 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		18BF668C2AC2097400C53C07 /* DefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultButton.swift; sourceTree = "<group>"; };
 		18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedBackStackView.swift; sourceTree = "<group>"; };
@@ -90,6 +94,22 @@
 			path = Helper;
 			sourceTree = "<group>";
 		};
+		18B97AEF2AC3C55C006C0AAA /* Extenstions */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Extenstions;
+			sourceTree = "<group>";
+		};
+		18B97AF22AC3C783006C0AAA /* Enum */ = {
+			isa = PBXGroup;
+			children = (
+				18B97AF32AC3C819006C0AAA /* QuizResultType.swift */,
+				18A815B92AC3E1D3007FE489 /* QuizType.swift */,
+			);
+			path = Enum;
+			sourceTree = "<group>";
+		};
 		18BF668B2AC208F500C53C07 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +137,8 @@
 		18E0D1EF2AC1305D005DDA6F /* oewoboka */ = {
 			isa = PBXGroup;
 			children = (
+				18B97AF22AC3C783006C0AAA /* Enum */,
+				18B97AEF2AC3C55C006C0AAA /* Extenstions */,
 				18BF668B2AC208F500C53C07 /* View */,
 				084C45F32AC1A9E2002999DF /* Helper */,
 				18E0D20B2AC13237005DDA6F /* Resource */,
@@ -327,6 +349,7 @@
 				18E0D2172AC133A2005DDA6F /* FeatureViewController.swift in Sources */,
 				18E0D2282AC1930F005DDA6F /* QuizCompleteViewController.swift in Sources */,
 				084C45ED2AC1943E002999DF /* FeatureCollectionViewCell.swift in Sources */,
+				18B97AF42AC3C819006C0AAA /* QuizResultType.swift in Sources */,
 				084C45EB2AC1934D002999DF /* FeatureViewModel.swift in Sources */,
 				084C45F22AC1A9CB002999DF /* FeatureCellModels.swift in Sources */,
 				18E0D20D2AC13264005DDA6F /* AddVocaViewController.swift in Sources */,
@@ -339,6 +362,7 @@
 				18E0D1F52AC1305D005DDA6F /* TabBarController.swift in Sources */,
 				18E0D2202AC17ED7005DDA6F /* Word.swift in Sources */,
 				18E0D2252AC18B90005DDA6F /* QuizControlStackView.swift in Sources */,
+				18A815BA2AC3E1D3007FE489 /* QuizType.swift in Sources */,
 				18E0D1F12AC1305D005DDA6F /* AppDelegate.swift in Sources */,
 				18E0D2232AC181CB005DDA6F /* CardView.swift in Sources */,
 				18E0D1F32AC1305D005DDA6F /* SceneDelegate.swift in Sources */,

--- a/oewoboka/oewoboka.xcodeproj/project.pbxproj
+++ b/oewoboka/oewoboka.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		18E0D2232AC181CB005DDA6F /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2222AC181CB005DDA6F /* CardView.swift */; };
 		18E0D2252AC18B90005DDA6F /* QuizControlStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2242AC18B90005DDA6F /* QuizControlStackView.swift */; };
 		18E0D2282AC1930F005DDA6F /* QuizCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D2272AC1930F005DDA6F /* QuizCompleteViewController.swift */; };
-		18E0D22B2AC19344005DDA6F /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D22A2AC19344005DDA6F /* ResultView.swift */; };
+		18E0D22B2AC19344005DDA6F /* CircleProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D22A2AC19344005DDA6F /* CircleProgressBar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,7 +74,7 @@
 		18E0D2222AC181CB005DDA6F /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		18E0D2242AC18B90005DDA6F /* QuizControlStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizControlStackView.swift; sourceTree = "<group>"; };
 		18E0D2272AC1930F005DDA6F /* QuizCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizCompleteViewController.swift; sourceTree = "<group>"; };
-		18E0D22A2AC19344005DDA6F /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		18E0D22A2AC19344005DDA6F /* CircleProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleProgressBar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +126,7 @@
 		18BF668B2AC208F500C53C07 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				18E0D22A2AC19344005DDA6F /* CircleProgressBar.swift */,
 				18BF668C2AC2097400C53C07 /* DefaultButton.swift */,
 			);
 			path = View;
@@ -306,7 +307,6 @@
 		18E0D2292AC1932F005DDA6F /* View */ = {
 			isa = PBXGroup;
 			children = (
-				18E0D22A2AC19344005DDA6F /* ResultView.swift */,
 				18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */,
 			);
 			path = View;
@@ -402,7 +402,7 @@
 				18CE95B22AC6D84900CAA133 /* BottomSheetPresentationController.swift in Sources */,
 				18BF668A2AC208B300C53C07 /* Typography.swift in Sources */,
 				18E0D2132AC13388005DDA6F /* QuizViewController.swift in Sources */,
-				18E0D22B2AC19344005DDA6F /* ResultView.swift in Sources */,
+				18E0D22B2AC19344005DDA6F /* CircleProgressBar.swift in Sources */,
 				18E0D21E2AC17E94005DDA6F /* Vocabulary.swift in Sources */,
 				18E0D21B2AC133FE005DDA6F /* AddVocabularyViewController.swift in Sources */,
 				18E0D1F52AC1305D005DDA6F /* TabBarController.swift in Sources */,

--- a/oewoboka/oewoboka.xcodeproj/project.pbxproj
+++ b/oewoboka/oewoboka.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		084C45F52AC1A9FA002999DF /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084C45F42AC1A9FA002999DF /* Constant.swift */; };
 		18BF668A2AC208B300C53C07 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF66892AC208B300C53C07 /* Typography.swift */; };
 		18BF668D2AC2097400C53C07 /* DefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF668C2AC2097400C53C07 /* DefaultButton.swift */; };
+		18CE9BE72AC2CA9900D39403 /* FeedBackStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */; };
 		18E0D1F12AC1305D005DDA6F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D1F02AC1305D005DDA6F /* AppDelegate.swift */; };
 		18E0D1F32AC1305D005DDA6F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D1F22AC1305D005DDA6F /* SceneDelegate.swift */; };
 		18E0D1F52AC1305D005DDA6F /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0D1F42AC1305D005DDA6F /* TabBarController.swift */; };
@@ -39,6 +40,7 @@
 		084C45F42AC1A9FA002999DF /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		18BF66892AC208B300C53C07 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		18BF668C2AC2097400C53C07 /* DefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultButton.swift; sourceTree = "<group>"; };
+		18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedBackStackView.swift; sourceTree = "<group>"; };
 		18E0D1ED2AC1305D005DDA6F /* oewoboka.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = oewoboka.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		18E0D1F02AC1305D005DDA6F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		18E0D1F22AC1305D005DDA6F /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 			isa = PBXGroup;
 			children = (
 				18E0D22A2AC19344005DDA6F /* ResultView.swift */,
+				18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -339,6 +342,7 @@
 				18E0D1F12AC1305D005DDA6F /* AppDelegate.swift in Sources */,
 				18E0D2232AC181CB005DDA6F /* CardView.swift in Sources */,
 				18E0D1F32AC1305D005DDA6F /* SceneDelegate.swift in Sources */,
+				18CE9BE72AC2CA9900D39403 /* FeedBackStackView.swift in Sources */,
 				084C45F52AC1A9FA002999DF /* Constant.swift in Sources */,
 				18BF668D2AC2097400C53C07 /* DefaultButton.swift in Sources */,
 			);

--- a/oewoboka/oewoboka.xcodeproj/project.pbxproj
+++ b/oewoboka/oewoboka.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		18C3457F2ACA638C0072995F /* TopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C3457E2ACA638C0072995F /* TopView.swift */; };
 		18C345812ACA67F90072995F /* BottomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C345802ACA67F90072995F /* BottomView.swift */; };
 		18C345842ACA6CB30072995F /* AnswerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C345832ACA6CB30072995F /* AnswerTableViewCell.swift */; };
+		18C345862ACA8CFC0072995F /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C345852ACA8CFC0072995F /* BottomSheetViewController.swift */; };
 		18CE95B22AC6D84900CAA133 /* BottomSheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE95B12AC6D84900CAA133 /* BottomSheetPresentationController.swift */; };
 		18CE95B42AC6DAF400CAA133 /* AnswerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE95B32AC6DAF400CAA133 /* AnswerViewController.swift */; };
 		18CE9BE72AC2CA9900D39403 /* FeedBackStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */; };
@@ -52,6 +53,7 @@
 		18C3457E2ACA638C0072995F /* TopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopView.swift; sourceTree = "<group>"; };
 		18C345802ACA67F90072995F /* BottomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomView.swift; sourceTree = "<group>"; };
 		18C345832ACA6CB30072995F /* AnswerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerTableViewCell.swift; sourceTree = "<group>"; };
+		18C345852ACA8CFC0072995F /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		18CE95B12AC6D84900CAA133 /* BottomSheetPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresentationController.swift; sourceTree = "<group>"; };
 		18CE95B32AC6DAF400CAA133 /* AnswerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerViewController.swift; sourceTree = "<group>"; };
 		18CE9BE62AC2CA9900D39403 /* FeedBackStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedBackStackView.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			children = (
 				084C45F42AC1A9FA002999DF /* Constant.swift */,
 				18BF66892AC208B300C53C07 /* Typography.swift */,
+				18C345852ACA8CFC0072995F /* BottomSheetViewController.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -395,6 +398,7 @@
 				18E0D20D2AC13264005DDA6F /* AddVocaViewController.swift in Sources */,
 				18E0D2192AC133AD005DDA6F /* VocaListViewController.swift in Sources */,
 				18C345812ACA67F90072995F /* BottomView.swift in Sources */,
+				18C345862ACA8CFC0072995F /* BottomSheetViewController.swift in Sources */,
 				18CE95B22AC6D84900CAA133 /* BottomSheetPresentationController.swift in Sources */,
 				18BF668A2AC208B300C53C07 /* Typography.swift in Sources */,
 				18E0D2132AC13388005DDA6F /* QuizViewController.swift in Sources */,

--- a/oewoboka/oewoboka/Enum/QuizResultType.swift
+++ b/oewoboka/oewoboka/Enum/QuizResultType.swift
@@ -1,0 +1,12 @@
+//
+//  QuizResultType.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/27.
+//
+
+enum QuizResultType {
+    case answer
+    case allReQuiz
+    case unMemorizeReQuiz
+}

--- a/oewoboka/oewoboka/Enum/QuizType.swift
+++ b/oewoboka/oewoboka/Enum/QuizType.swift
@@ -1,0 +1,13 @@
+//
+//  QuizType.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/27.
+//
+
+enum QuizType {
+    case training
+    case wordDictation
+    case meanDictation
+    case test
+}

--- a/oewoboka/oewoboka/Helper/BottomSheetViewController.swift
+++ b/oewoboka/oewoboka/Helper/BottomSheetViewController.swift
@@ -9,8 +9,13 @@ import UIKit
 
 class BottomSheetViewController: UIViewController {
     
-    private var isDismissTouch: Bool = false
+    private var isDismissDragging: Bool = false
+    
+    // view의 처음 높이(팝업뷰 드래그시 이 위치보다 더 높아지지 않음)
     private let originY: CGFloat
+    
+    // 팝업뷰를 닫기 위해 터치시, 터치가 적용되는 영역 높이 설정 (터치 영역보다 더 아래쪽을 클릭시 팝업뷰가 내려가지 않음)
+    var dismissTouchHeightArea: CGFloat = 44
     
     init(originY: CGFloat) {
         self.originY = originY
@@ -28,14 +33,14 @@ extension BottomSheetViewController {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let window = UIApplication.shared.windows.first,
               let location = touches.first?.location(in: window),
-              location.y <= originY + 40 else { return }
-        isDismissTouch = true
+              location.y <= originY + dismissTouchHeightArea else { return }
+        isDismissDragging = true
     }
     
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         let window = UIApplication.shared.windows.first
         guard let location = touches.first?.location(in: window),
-            isDismissTouch else { return }
+            isDismissDragging else { return }
         guard location.y > originY else {
             view.frame.origin.y = originY
             return
@@ -45,7 +50,7 @@ extension BottomSheetViewController {
     
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         
-        guard isDismissTouch,
+        guard isDismissDragging,
               let window = UIApplication.shared.windows.first,
               let touch = touches.first else { return }
         
@@ -58,7 +63,7 @@ extension BottomSheetViewController {
         if location.y >= dismissY { dismiss(animated: true) }
         else if isFasterDown { dismiss(animated: true) }
         else {
-            isDismissTouch = false
+            isDismissDragging = false
             UIView.animate(withDuration: 0.1) {
                 self.view.frame.origin.y = self.originY
             }

--- a/oewoboka/oewoboka/Helper/BottomSheetViewController.swift
+++ b/oewoboka/oewoboka/Helper/BottomSheetViewController.swift
@@ -1,0 +1,67 @@
+//
+//  BottomSheetViewController.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/10/02.
+//
+
+import UIKit
+
+class BottomSheetViewController: UIViewController {
+    
+    private var isDismissTouch: Bool = false
+    private let originY: CGFloat
+    
+    init(originY: CGFloat) {
+        self.originY = originY
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+// MARK: TouchEvent
+extension BottomSheetViewController {
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let window = UIApplication.shared.windows.first,
+              let location = touches.first?.location(in: window),
+              location.y <= originY + 40 else { return }
+        isDismissTouch = true
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        let window = UIApplication.shared.windows.first
+        guard let location = touches.first?.location(in: window),
+            isDismissTouch else { return }
+        guard location.y > originY else {
+            view.frame.origin.y = originY
+            return
+        }
+        view.frame.origin.y = location.y
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        
+        guard isDismissTouch,
+              let window = UIApplication.shared.windows.first,
+              let touch = touches.first else { return }
+        
+        let previousLocation = touch.previousLocation(in: window)
+        let location = touch.location(in: window)
+        
+        let dismissY = originY + 200
+        let isFasterDown = (location.y - previousLocation.y) >= 7
+        
+        if location.y >= dismissY { dismiss(animated: true) }
+        else if isFasterDown { dismiss(animated: true) }
+        else {
+            isDismissTouch = false
+            UIView.animate(withDuration: 0.1) {
+                self.view.frame.origin.y = self.originY
+            }
+        }
+    }
+}

--- a/oewoboka/oewoboka/Resource/SceneDelegate.swift
+++ b/oewoboka/oewoboka/Resource/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
         window.backgroundColor = .white
-        window.rootViewController = UINavigationController(rootViewController: TabBarViewController())
+        window.rootViewController = UINavigationController(rootViewController: QuizViewController())
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/oewoboka/oewoboka/Resource/SceneDelegate.swift
+++ b/oewoboka/oewoboka/Resource/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
         window.backgroundColor = .white
-        window.rootViewController = UINavigationController(rootViewController: QuizViewController(quizType: .training))
+        window.rootViewController = TabBarViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/oewoboka/oewoboka/Resource/SceneDelegate.swift
+++ b/oewoboka/oewoboka/Resource/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
         window.backgroundColor = .white
-        window.rootViewController = UINavigationController(rootViewController: QuizViewController())
+        window.rootViewController = UINavigationController(rootViewController: QuizViewController(quizType: .training))
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
@@ -87,7 +87,7 @@ extension AnswerViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: AnswerTableViewCell.identifier, for: indexPath) as? AnswerTableViewCell else { return UITableViewCell() }
         let word = words[indexPath.row]
-        cell.numberLabel.text = "\(indexPath.row)"
+        cell.numberLabel.text = "\(indexPath.row + 1)."
         cell.vocabularyTitleLabel.text = word.vocabularyTitle
         cell.englishWordLabel.text = word.english
         cell.koreaWordLabel.text = word.korea

--- a/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
@@ -14,7 +14,7 @@ class AnswerViewController: BottomSheetViewController {
     private let answerTableView: UITableView = UITableView()
     private let answerBottomView: BottomView = BottomView()
     
-    let words: [Word]
+    var words: [Word]
     
     init(words: [Word]) {
         self.words = words
@@ -38,6 +38,8 @@ private extension AnswerViewController {
         mainViewSetup()
         addView()
         tableViewSetup()
+        topViewSetup()
+        bottomViewSetup()
         autoLayoutSetup()
     }
     
@@ -59,6 +61,34 @@ private extension AnswerViewController {
         answerTableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
     
+    func topViewSetup() {
+        answerTopView.closeButtonClickHandler = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+    }
+    
+    func bottomViewSetup() {
+        let answerWords = words.filter { $0.isMemorize }
+        answerBottomView.unBookMarkHandler = { [weak self] in
+            guard let self else { return }
+            for word in answerWords {
+                guard let wordIndex = words.firstIndex(where: { $0.id == word.id }) else { continue }
+                self.words[wordIndex].isBookmark = false
+            }
+            self.answerTableView.reloadData()
+        }
+        
+        let noAnswerWords = words.filter { $0.isMemorize == false }
+        answerBottomView.bookMarkHandler = { [weak self] in
+            guard let self else { return }
+            for word in noAnswerWords {
+                guard let wordIndex = words.firstIndex(where: { $0.id == word.id }) else { continue }
+                self.words[wordIndex].isBookmark = true
+            }
+            self.answerTableView.reloadData()
+        }
+    }
+    
     func autoLayoutSetup() {
         let safeArea = view.safeAreaLayoutGuide
         answerTopView.snp.makeConstraints { make in
@@ -73,6 +103,7 @@ private extension AnswerViewController {
             make.left.right.bottom.equalTo(safeArea)
         }
     }
+    
 }
 
 // MARK: TableView
@@ -89,6 +120,11 @@ extension AnswerViewController: UITableViewDelegate, UITableViewDataSource {
         cell.vocabularyTitleLabel.text = word.vocabularyTitle
         cell.englishWordLabel.text = word.english
         cell.koreaWordLabel.text = word.korea
+        cell.bookMarkButton.isSelected = word.isBookmark
+        cell.wordBookmarkUpdate = { [weak self] isSelected in
+            guard let self else { return }
+            self.words[indexPath.row].isBookmark = isSelected
+        }
         return cell
     }
 }

--- a/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
@@ -8,19 +8,17 @@
 import UIKit
 import SnapKit
 
-class AnswerViewController: UIViewController {
+class AnswerViewController: BottomSheetViewController {
     
     private let answerTopView: TopView = TopView(title: "정답 보기")
     private let answerTableView: UITableView = UITableView()
     private let answerBottomView: BottomView = BottomView()
     
-    private var isDismissTouch: Bool = false
-    private let originY: CGFloat = Constant.screenHeight * 0.2
     let words: [Word]
     
     init(words: [Word]) {
         self.words = words
-        super.init(nibName: nil, bundle: nil)
+        super.init(originY: Constant.screenHeight * 0.2)
     }
     
     required init?(coder: NSCoder) {
@@ -92,48 +90,5 @@ extension AnswerViewController: UITableViewDelegate, UITableViewDataSource {
         cell.englishWordLabel.text = word.english
         cell.koreaWordLabel.text = word.korea
         return cell
-    }
-}
-
-// MARK: TouchEvent
-extension AnswerViewController {
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let window = UIApplication.shared.windows.first,
-              let location = touches.first?.location(in: window),
-              location.y <= originY + 40 else { return }
-        isDismissTouch = true
-    }
-    
-    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        let window = UIApplication.shared.windows.first
-        guard let location = touches.first?.location(in: window),
-            isDismissTouch else { return }
-        guard location.y > originY else {
-            view.frame.origin.y = originY
-            return
-        }
-        view.frame.origin.y = location.y
-    }
-    
-    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        
-        guard isDismissTouch,
-              let window = UIApplication.shared.windows.first,
-              let touch = touches.first else { return }
-        
-        let previousLocation = touch.previousLocation(in: window)
-        let location = touch.location(in: window)
-        
-        let dismissY = originY + 200
-        let isFasterDown = (location.y - previousLocation.y) >= 7
-        
-        if location.y >= dismissY { dismiss(animated: true) }
-        else if isFasterDown { dismiss(animated: true) }
-        else {
-            isDismissTouch = false
-            UIView.animate(withDuration: 0.1) {
-                self.view.frame.origin.y = self.originY
-            }
-        }
     }
 }

--- a/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/AnswerViewController.swift
@@ -1,0 +1,139 @@
+//
+//  AnswerViewController.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/29.
+//
+
+import UIKit
+import SnapKit
+
+class AnswerViewController: UIViewController {
+    
+    private let answerTopView: TopView = TopView(title: "정답 보기")
+    private let answerTableView: UITableView = UITableView()
+    private let answerBottomView: BottomView = BottomView()
+    
+    private var isDismissTouch: Bool = false
+    private let originY: CGFloat = Constant.screenHeight * 0.2
+    let words: [Word]
+    
+    init(words: [Word]) {
+        self.words = words
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+
+}
+
+// MARK: UI Init
+private extension AnswerViewController {
+    func setup() {
+        mainViewSetup()
+        addView()
+        tableViewSetup()
+        autoLayoutSetup()
+    }
+    
+    func mainViewSetup() {
+        view.layer.cornerRadius = 15
+        view.backgroundColor = .white
+    }
+    
+    func addView() {
+        view.addSubview(answerTopView)
+        view.addSubview(answerTableView)
+        view.addSubview(answerBottomView)
+    }
+    
+    func tableViewSetup() {
+        answerTableView.dataSource = self
+        answerTableView.delegate = self
+        answerTableView.register(AnswerTableViewCell.self, forCellReuseIdentifier: AnswerTableViewCell.identifier)
+        answerTableView.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    }
+    
+    func autoLayoutSetup() {
+        let safeArea = view.safeAreaLayoutGuide
+        answerTopView.snp.makeConstraints { make in
+            make.top.left.right.equalToSuperview()
+        }
+        answerTableView.snp.makeConstraints { make in
+            make.top.equalTo(answerTopView.snp.bottom)
+            make.left.right.equalToSuperview()
+            make.bottom.equalTo(answerBottomView.snp.top)
+        }
+        answerBottomView.snp.makeConstraints { make in
+            make.left.right.bottom.equalTo(safeArea)
+        }
+    }
+}
+
+// MARK: TableView
+
+extension AnswerViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return words.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: AnswerTableViewCell.identifier, for: indexPath) as? AnswerTableViewCell else { return UITableViewCell() }
+        let word = words[indexPath.row]
+        cell.numberLabel.text = "\(indexPath.row)"
+        cell.vocabularyTitleLabel.text = word.vocabularyTitle
+        cell.englishWordLabel.text = word.english
+        cell.koreaWordLabel.text = word.korea
+        return cell
+    }
+}
+
+// MARK: TouchEvent
+extension AnswerViewController {
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        guard let window = UIApplication.shared.windows.first,
+              let location = touches.first?.location(in: window),
+              location.y <= originY + 40 else { return }
+        isDismissTouch = true
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        let window = UIApplication.shared.windows.first
+        guard let location = touches.first?.location(in: window),
+            isDismissTouch else { return }
+        guard location.y > originY else {
+            view.frame.origin.y = originY
+            return
+        }
+        view.frame.origin.y = location.y
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        
+        guard isDismissTouch,
+              let window = UIApplication.shared.windows.first,
+              let touch = touches.first else { return }
+        
+        let previousLocation = touch.previousLocation(in: window)
+        let location = touch.location(in: window)
+        
+        let dismissY = originY + 200
+        let isFasterDown = (location.y - previousLocation.y) >= 7
+        
+        if location.y >= dismissY { dismiss(animated: true) }
+        else if isFasterDown { dismiss(animated: true) }
+        else {
+            isDismissTouch = false
+            UIView.animate(withDuration: 0.1) {
+                self.view.frame.origin.y = self.originY
+            }
+        }
+    }
+}

--- a/oewoboka/oewoboka/Scenes/AnswerPage/BottomSheetPresentationController.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/BottomSheetPresentationController.swift
@@ -1,0 +1,29 @@
+//
+//  BottomSheetPresentationController.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/29.
+//
+
+import UIKit
+import SnapKit
+
+class BottomSheetPresentationController: UIPresentationController {
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard var frame = containerView?.frame else {
+            return .zero
+        }
+        frame.origin.y = Constant.screenHeight * 0.2
+        frame.size.height = Constant.screenHeight * 0.8
+        return frame
+    }
+    
+    override func presentationTransitionWillBegin() {
+        super.presentationTransitionWillBegin()
+        
+        guard let containerView else { return }
+        
+        containerView.backgroundColor = .clear.withAlphaComponent(0.5)
+    }
+}

--- a/oewoboka/oewoboka/Scenes/AnswerPage/Cell/AnswerTableViewCell.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/Cell/AnswerTableViewCell.swift
@@ -1,0 +1,110 @@
+//
+//  AnswerTableViewCell.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/10/02.
+//
+
+import UIKit
+import SnapKit
+
+class AnswerTableViewCell: UITableViewCell {
+    static let identifier: String = "\(AnswerTableViewCell.self)"
+    private let topView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fill
+        stackView.spacing = 0
+        return stackView
+    }()
+    let numberLabel: UILabel = {
+        let label = UILabel()
+        label.font = Typography.body3.font
+        label.textColor = .systemGray4
+        return label
+    }()
+    let vocabularyTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = Typography.body3.font
+        label.textColor = .systemGray4
+        return label
+    }()
+    let bookMarkButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "bookmark"), for: .normal)
+        button.tintColor = button.isSelected ? .red : .black
+        return button
+    }()
+    private let wordStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        return stackView
+    }()
+    let englishWordLabel: UILabel = {
+        let label = UILabel()
+        label.font = Typography.body1.font
+        label.textColor = .red
+        return label
+    }()
+    let koreaWordLabel: UILabel = {
+        let label = UILabel()
+        label.font = Typography.body2.font
+        label.textColor = .black
+        return label
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+// MARK: UI Init
+private extension AnswerTableViewCell {
+    func setup() {
+        addView()
+        topViewSetup()
+        autoLayoutSetup()
+    }
+    
+    func addView() {
+        contentView.addSubview(topView)
+        contentView.addSubview(wordStackView)
+        topView.addArrangedSubview(numberLabel)
+        topView.addArrangedSubview(vocabularyTitleLabel)
+        topView.addArrangedSubview(bookMarkButton)
+        wordStackView.addArrangedSubview(englishWordLabel)
+        wordStackView.addArrangedSubview(koreaWordLabel)
+    }
+    
+    func topViewSetup() {
+        
+    }
+    
+    func autoLayoutSetup() {
+        numberLabel.snp.makeConstraints { make in
+            make.width.height.equalTo(32)
+        }
+        bookMarkButton.snp.makeConstraints { make in
+            make.width.height.equalTo(32)
+        }
+        topView.snp.makeConstraints { make in
+            make.top.equalTo(contentView)
+            make.left.right.equalTo(contentView).inset(8)
+        }
+        wordStackView.snp.makeConstraints { make in
+            make.top.equalTo(topView.snp.bottom)
+            make.bottom.equalTo(contentView.snp.bottom).inset(12)
+            make.left.equalTo(contentView).inset(8)
+        }
+    }
+}

--- a/oewoboka/oewoboka/Scenes/AnswerPage/Cell/AnswerTableViewCell.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/Cell/AnswerTableViewCell.swift
@@ -33,6 +33,7 @@ class AnswerTableViewCell: UITableViewCell {
     let bookMarkButton: UIButton = {
         let button = UIButton()
         button.setImage(UIImage(systemName: "bookmark"), for: .normal)
+        button.setImage(UIImage(systemName: "bookmark.fill"), for: .selected)
         button.tintColor = button.isSelected ? .red : .black
         return button
     }()
@@ -56,6 +57,8 @@ class AnswerTableViewCell: UITableViewCell {
         label.textColor = .black
         return label
     }()
+    var wordBookmarkUpdate: ((Bool) -> Void)?
+    
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -72,7 +75,7 @@ class AnswerTableViewCell: UITableViewCell {
 private extension AnswerTableViewCell {
     func setup() {
         addView()
-        topViewSetup()
+        buttonSetup()
         autoLayoutSetup()
     }
     
@@ -86,8 +89,13 @@ private extension AnswerTableViewCell {
         wordStackView.addArrangedSubview(koreaWordLabel)
     }
     
-    func topViewSetup() {
-        
+    func buttonSetup() {
+        bookMarkButton.addTarget(self, action: #selector(bookmarkButtonClick), for: .touchUpInside)
+    }
+    
+    @objc func bookmarkButtonClick() {
+        bookMarkButton.isSelected.toggle()
+        wordBookmarkUpdate?(bookMarkButton.isSelected)
     }
     
     func autoLayoutSetup() {

--- a/oewoboka/oewoboka/Scenes/AnswerPage/View/BottomView.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/View/BottomView.swift
@@ -1,0 +1,69 @@
+//
+//  BottomView.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/10/02.
+//
+
+import UIKit
+
+class BottomView: UIStackView {
+    
+    private let unBookMarkButton: DefaultButton = {
+        let button = DefaultButton()
+        button.image = UIImage(systemName: "bookmark.slash")
+        button.text = "맞은 단어를 마크 해제"
+        return button
+    }()
+    private let bookMarkButton: DefaultButton = {
+        let button = DefaultButton()
+        button.image = UIImage(systemName: "bookmark")
+        button.text = "틀린 단어를 마크"
+        return button
+    }()
+    private let topLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension BottomView {
+    func setup() {
+        stackViewInit()
+        addViews()
+        autoLayoutSetup()
+    }
+    
+    func stackViewInit() {
+        axis = .vertical
+        alignment = .fill
+        distribution = .fillEqually
+        spacing = 12
+        isLayoutMarginsRelativeArrangement = true
+        layoutMargins = UIEdgeInsets(top: spacing, left: 16, bottom: 0, right: 16)
+    }
+    
+    func addViews() {
+        addArrangedSubview(unBookMarkButton)
+        addArrangedSubview(bookMarkButton)
+        addSubview(topLineView)
+    }
+    
+    func autoLayoutSetup() {
+        topLineView.snp.makeConstraints { make in
+            make.top.left.right.equalToSuperview()
+            make.height.equalTo(0.5)
+        }
+    }
+}

--- a/oewoboka/oewoboka/Scenes/AnswerPage/View/BottomView.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/View/BottomView.swift
@@ -21,6 +21,8 @@ class BottomView: UIStackView {
         button.text = "틀린 단어를 마크"
         return button
     }()
+    var unBookMarkHandler: (() -> Void)?
+    var bookMarkHandler: (() -> Void)?
     private let topLineView: UIView = {
         let view = UIView()
         view.backgroundColor = .gray
@@ -42,6 +44,7 @@ private extension BottomView {
     func setup() {
         stackViewInit()
         addViews()
+        buttonSetup()
         autoLayoutSetup()
     }
     
@@ -58,6 +61,19 @@ private extension BottomView {
         addArrangedSubview(unBookMarkButton)
         addArrangedSubview(bookMarkButton)
         addSubview(topLineView)
+    }
+    
+    func buttonSetup() {
+        unBookMarkButton.addTarget(self, action: #selector(unBookMarkButtonClick), for: .touchUpInside)
+        bookMarkButton.addTarget(self, action: #selector(bookMarkButtonClick), for: .touchUpInside)
+    }
+    
+    @objc func unBookMarkButtonClick() {
+        unBookMarkHandler?()
+    }
+    
+    @objc func bookMarkButtonClick() {
+        bookMarkHandler?()
     }
     
     func autoLayoutSetup() {

--- a/oewoboka/oewoboka/Scenes/AnswerPage/View/TopView.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/View/TopView.swift
@@ -30,6 +30,8 @@ class TopView: UIStackView {
         return view
     }()
     
+    var closeButtonClickHandler: (() -> Void)?
+    
     init(title: String) {
         super.init(frame: .zero)
         titleLabel.text = title
@@ -46,6 +48,7 @@ private extension TopView {
     func setup() {
         stackViewInit()
         addViews()
+        buttonSetup()
         autoLayoutSetup()
     }
     
@@ -60,6 +63,14 @@ private extension TopView {
         addArrangedSubview(titleLabel)
         addArrangedSubview(closeButton)
         addSubview(bottomLineView)
+    }
+    
+    func buttonSetup() {
+        closeButton.addTarget(self, action: #selector(closeButtonClick), for: .touchUpInside)
+    }
+    
+    @objc func closeButtonClick() {
+        closeButtonClickHandler?()
     }
     
     func autoLayoutSetup() {

--- a/oewoboka/oewoboka/Scenes/AnswerPage/View/TopView.swift
+++ b/oewoboka/oewoboka/Scenes/AnswerPage/View/TopView.swift
@@ -1,0 +1,77 @@
+//
+//  TopView.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/10/02.
+//
+
+import UIKit
+import SnapKit
+
+class TopView: UIStackView {
+    
+    private let spacerView: UIView = UIView()
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = Typography.title3.font
+        label.textColor = .black
+        label.textAlignment = .center
+        return label
+    }()
+    private let closeButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = .black
+        return button
+    }()
+    private let bottomLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .gray
+        return view
+    }()
+    
+    init(title: String) {
+        super.init(frame: .zero)
+        titleLabel.text = title
+        setup()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension TopView {
+    func setup() {
+        stackViewInit()
+        addViews()
+        autoLayoutSetup()
+    }
+    
+    func stackViewInit() {
+        axis = .horizontal
+        alignment = .fill
+        distribution = .fill
+    }
+    
+    func addViews() {
+        addArrangedSubview(spacerView)
+        addArrangedSubview(titleLabel)
+        addArrangedSubview(closeButton)
+        addSubview(bottomLineView)
+    }
+    
+    func autoLayoutSetup() {
+        spacerView.snp.makeConstraints { make in
+            make.width.height.equalTo(44)
+        }
+        closeButton.snp.makeConstraints { make in
+            make.width.height.equalTo(44)
+        }
+        bottomLineView.snp.makeConstraints { make in
+            make.bottom.left.right.equalToSuperview()
+            make.height.equalTo(0.5)
+        }
+    }
+}

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -39,6 +39,7 @@ private extension QuizCompleteViewController {
         autoLayoutSetup()
         resultViewSetup()
         quizFeedbackSetup()
+        navigationSetup()
     }
     
     func addViews() {
@@ -55,7 +56,11 @@ private extension QuizCompleteViewController {
         quizFeedbackStackView.popHandler = { [weak self] resultType in
             switch resultType {
             case .answer:
-                self?.popCompletion?(nil)
+                guard let self else { return }
+                let vc = AnswerViewController(words: self.quizResultWords)
+                vc.modalPresentationStyle = .custom
+                vc.transitioningDelegate = self
+                self.present(vc, animated: true)
             case .allReQuiz:
                 self?.popCompletion?(self?.quizResultWords)
             case .unMemorizeReQuiz:
@@ -75,5 +80,21 @@ private extension QuizCompleteViewController {
         quizFeedbackStackView.snp.makeConstraints { make in
             make.left.right.bottom.equalTo(safeArea).inset(24)
         }
+    }
+    
+    func navigationSetup() {
+        navigationItem.hidesBackButton = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "test", style: .plain, target: self, action: #selector(backButtonClick))
+    }
+    
+    @objc func backButtonClick() {
+        navigationController?.popToRootViewController(animated: true)
+        
+    }
+}
+
+extension QuizCompleteViewController: UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        return BottomSheetPresentationController(presentedViewController: presented, presenting: presenting)
     }
 }

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class QuizCompleteViewController: UIViewController {
     
     private let middleView: UIView = UIView()
-    private let resultView: ResultView
+    private let resultView: CircleProgressBar
     private let quizFeedbackStackView: FeedBackStackView = FeedBackStackView()
     private let quizResultWords: [Word]
     var popCompletion: (([Word]?) -> Void)?
@@ -19,7 +19,7 @@ final class QuizCompleteViewController: UIViewController {
         quizResultWords = words
         let memorizeWords = quizResultWords.filter { $0.isMemorize }
         let rate = CGFloat(memorizeWords.count) / CGFloat(quizResultWords.count)
-        resultView = ResultView(correctRate: rate, allWordCount: quizResultWords.count, isMemorizeCount: memorizeWords.count)
+        resultView = CircleProgressBar(correctRate: rate, type: .percent, allWordCount: quizResultWords.count, isMemorizeCount: memorizeWords.count)
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -1,0 +1,43 @@
+//
+//  QuizCompleteViewController.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/25.
+//
+
+import UIKit
+
+final class QuizCompleteViewController: UIViewController {
+    
+    let resultView: ResultView = ResultView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+
+}
+
+private extension QuizCompleteViewController {
+    func setup() {
+        addViews()
+        autoLayoutSetup()
+        resultViewSetup()
+    }
+    
+    func addViews() {
+        view.addSubview(resultView)
+    }
+    
+    func resultViewSetup() {
+        resultView.progressBarSetupAnimation()
+    }
+    
+    func autoLayoutSetup() {
+        let safeArea = view.safeAreaLayoutGuide
+        resultView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.height.width.equalTo(safeArea.snp.width).dividedBy(2)
+        }
+    }
+}

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -89,13 +89,14 @@ private extension QuizCompleteViewController {
     }
     
     func navigationSetup() {
+        let backBarButton = UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(backButtonClick))
+        backBarButton.tintColor = .black
         navigationItem.hidesBackButton = true
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "test", style: .plain, target: self, action: #selector(backButtonClick))
+        navigationItem.leftBarButtonItem = backBarButton
     }
     
     @objc func backButtonClick() {
         navigationController?.popToRootViewController(animated: true)
-        
     }
 }
 

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class QuizCompleteViewController: UIViewController {
     
+    private let middleView: UIView = UIView()
     private let resultView: ResultView
     private let quizFeedbackStackView: FeedBackStackView = FeedBackStackView()
     private let quizResultWords: [Word]
@@ -43,7 +44,8 @@ private extension QuizCompleteViewController {
     }
     
     func addViews() {
-        view.addSubview(resultView)
+        view.addSubview(middleView)
+        middleView.addSubview(resultView)
         view.addSubview(quizFeedbackStackView)
     }
     
@@ -73,6 +75,10 @@ private extension QuizCompleteViewController {
     
     func autoLayoutSetup() {
         let safeArea = view.safeAreaLayoutGuide
+        middleView.snp.makeConstraints { make in
+            make.top.left.right.equalTo(safeArea)
+            make.bottom.equalTo(quizFeedbackStackView.snp.top)
+        }
         resultView.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.height.width.equalTo(safeArea.snp.width).dividedBy(2)

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -9,9 +9,10 @@ import UIKit
 
 final class QuizCompleteViewController: UIViewController {
     
-    let resultView: ResultView
-    let quizFeedbackStackView: FeedBackStackView = FeedBackStackView()
-    let quizResultWords: [Word]
+    private let resultView: ResultView
+    private let quizFeedbackStackView: FeedBackStackView = FeedBackStackView()
+    private let quizResultWords: [Word]
+    var popCompletion: (([Word]?) -> Void)?
     
     init(words: [Word]) {
         quizResultWords = words
@@ -37,6 +38,7 @@ private extension QuizCompleteViewController {
         addViews()
         autoLayoutSetup()
         resultViewSetup()
+        quizFeedbackSetup()
     }
     
     func addViews() {
@@ -49,7 +51,19 @@ private extension QuizCompleteViewController {
     }
     
     func quizFeedbackSetup() {
-        quizFeedbackStackView.noMemoryCount = quizResultWords.filter{ $0.isMemorize }.count
+        quizFeedbackStackView.unMemorizeCount = quizResultWords.filter{ $0.isMemorize == false }.count
+        quizFeedbackStackView.popHandler = { [weak self] resultType in
+            switch resultType {
+            case .answer:
+                self?.popCompletion?(nil)
+            case .allReQuiz:
+                self?.popCompletion?(self?.quizResultWords)
+            case .unMemorizeReQuiz:
+                let unMemorizeWords = self?.quizResultWords.filter { $0.isMemorize == false }
+                self?.popCompletion?(unMemorizeWords)
+            }
+            self?.navigationController?.popViewController(animated: true)
+        }
     }
     
     func autoLayoutSetup() {

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -9,8 +9,22 @@ import UIKit
 
 final class QuizCompleteViewController: UIViewController {
     
-    let resultView: ResultView = ResultView()
-
+    let resultView: ResultView
+    let quizFeedbackStackView: FeedBackStackView = FeedBackStackView()
+    let quizResultWords: [Word]
+    
+    init(words: [Word]) {
+        quizResultWords = words
+        let memorizeWords = quizResultWords.filter { $0.isMemorize }
+        let rate = CGFloat(memorizeWords.count) / CGFloat(quizResultWords.count)
+        resultView = ResultView(correctRate: rate, allWordCount: quizResultWords.count, isMemorizeCount: memorizeWords.count)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
@@ -27,10 +41,15 @@ private extension QuizCompleteViewController {
     
     func addViews() {
         view.addSubview(resultView)
+        view.addSubview(quizFeedbackStackView)
     }
     
     func resultViewSetup() {
         resultView.progressBarSetupAnimation()
+    }
+    
+    func quizFeedbackSetup() {
+        quizFeedbackStackView.noMemoryCount = quizResultWords.filter{ $0.isMemorize }.count
     }
     
     func autoLayoutSetup() {
@@ -38,6 +57,9 @@ private extension QuizCompleteViewController {
         resultView.snp.makeConstraints { make in
             make.center.equalToSuperview()
             make.height.width.equalTo(safeArea.snp.width).dividedBy(2)
+        }
+        quizFeedbackStackView.snp.makeConstraints { make in
+            make.left.right.bottom.equalTo(safeArea).inset(24)
         }
     }
 }

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
@@ -9,27 +9,30 @@ import UIKit
 
 final class FeedBackStackView: UIStackView {
     
-    private let quizAnswer: DefaultButton = {
+    private let quizAnswerButton: DefaultButton = {
         let button = DefaultButton()
         button.image = UIImage(systemName: "exclamationmark.bubble")
         button.text = "퀴즈 정답보기"
         return button
     }()
-    private let reloadQuizButton: DefaultButton = {
+    private let reQuizButton: DefaultButton = {
         let button = DefaultButton()
         button.image = UIImage(systemName: "arrow.clockwise")
         button.text = "다시하기"
         return button
     }()
-    private let noMemoryWorkReloadButton: DefaultButton = {
+    private let unMemorizeWordReQuizButton: DefaultButton = {
         let button = DefaultButton()
         button.image = UIImage(systemName: "arrow.clockwise")
         button.text = "모르는 문제 다시 풀기"
         return button
     }()
-    var noMemoryCount: Int = 0 {
+    var popHandler: ((QuizResultType) -> Void)?
+    var unMemorizeCount: Int = 0 {
         didSet {
-            noMemoryWorkReloadButton.text = "모르는 \(noMemoryCount)문제 다시 풀기"
+            let isUnMemorizeWordZero = unMemorizeCount == 0
+            unMemorizeWordReQuizButton.isHidden = isUnMemorizeWordZero
+            unMemorizeWordReQuizButton.text = "모르는 \(unMemorizeCount)문제 다시 풀기"
         }
     }
 
@@ -49,6 +52,7 @@ private extension FeedBackStackView {
     func setup() {
         initStackView()
         addViews()
+        buttonSetup()
     }
     
     func initStackView() {
@@ -59,8 +63,24 @@ private extension FeedBackStackView {
     }
     
     func addViews() {
-        addArrangedSubview(quizAnswer)
-        addArrangedSubview(reloadQuizButton)
-        addArrangedSubview(noMemoryWorkReloadButton)
+        addArrangedSubview(quizAnswerButton)
+        addArrangedSubview(reQuizButton)
+        addArrangedSubview(unMemorizeWordReQuizButton)
+    }
+    
+    func buttonSetup() {
+        quizAnswerButton.addTarget(self, action: #selector(reQuizeButtonClik), for: .touchUpInside)
+        reQuizButton.addTarget(self, action: #selector(reQuizeButtonClik), for: .touchUpInside)
+        unMemorizeWordReQuizButton.addTarget(self, action: #selector(unMemorizeReQuizButtonClick), for: .touchUpInside)
+    }
+    
+    @objc private func quizAnswerButtonClick() {
+        popHandler?(.answer)
+    }
+    @objc private func reQuizeButtonClik() {
+        popHandler?(.allReQuiz)
+    }
+    @objc private func unMemorizeReQuizButtonClick() {
+        popHandler?(.unMemorizeReQuiz)
     }
 }

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
@@ -1,0 +1,69 @@
+//
+//  FeedBackStackView.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/26.
+//
+
+import UIKit
+
+final class FeedBackStackView: UIStackView {
+    
+    private let quizAnswer: DefaultButton = {
+        let button = DefaultButton()
+        button.image = UIImage(systemName: "exclamationmark.bubble")
+        button.text = "퀴즈 정답보기"
+        button.type = .center
+        return button
+    }()
+    private let reloadQuizButton: DefaultButton = {
+        let button = DefaultButton()
+        button.image = UIImage(systemName: "arrow.clockwise")
+        button.text = "다시하기"
+        button.type = .center
+        return button
+    }()
+    private let noMemoryWorkReloadButton: DefaultButton = {
+        let button = DefaultButton()
+        button.image = UIImage(systemName: "arrow.clockwise")
+        button.text = "모르는 문제 다시 풀기"
+        button.type = .center
+        return button
+    }()
+    var noMemoryCount: Int = 0 {
+        didSet {
+            noMemoryWorkReloadButton.text = "모르는 \(noMemoryCount)문제 다시 풀기"
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+//MARK: UI Init
+private extension FeedBackStackView {
+    func setup() {
+        initStackView()
+        addViews()
+    }
+    
+    func initStackView() {
+        axis = .vertical
+        alignment = .fill
+        distribution = .fill
+        spacing = 16
+    }
+    
+    func addViews() {
+        addArrangedSubview(quizAnswer)
+        addArrangedSubview(reloadQuizButton)
+        addArrangedSubview(noMemoryWorkReloadButton)
+    }
+}

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
@@ -69,7 +69,7 @@ private extension FeedBackStackView {
     }
     
     func buttonSetup() {
-        quizAnswerButton.addTarget(self, action: #selector(reQuizeButtonClik), for: .touchUpInside)
+        quizAnswerButton.addTarget(self, action: #selector(quizAnswerButtonClick), for: .touchUpInside)
         reQuizButton.addTarget(self, action: #selector(reQuizeButtonClik), for: .touchUpInside)
         unMemorizeWordReQuizButton.addTarget(self, action: #selector(unMemorizeReQuizButtonClick), for: .touchUpInside)
     }

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/FeedBackStackView.swift
@@ -13,21 +13,18 @@ final class FeedBackStackView: UIStackView {
         let button = DefaultButton()
         button.image = UIImage(systemName: "exclamationmark.bubble")
         button.text = "퀴즈 정답보기"
-        button.type = .center
         return button
     }()
     private let reloadQuizButton: DefaultButton = {
         let button = DefaultButton()
         button.image = UIImage(systemName: "arrow.clockwise")
         button.text = "다시하기"
-        button.type = .center
         return button
     }()
     private let noMemoryWorkReloadButton: DefaultButton = {
         let button = DefaultButton()
         button.image = UIImage(systemName: "arrow.clockwise")
         button.text = "모르는 문제 다시 풀기"
-        button.type = .center
         return button
     }()
     var noMemoryCount: Int = 0 {

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/ResultView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/ResultView.swift
@@ -87,7 +87,7 @@ extension ResultView {
         let arcCenter = CGPoint(x: bounds.width/2, y: bounds.height/2)
         let radius = bounds.width/2
         let calayer = CAShapeLayer()
-        let bezierPath = UIBezierPath(arcCenter: arcCenter, radius: radius, startAngle: -.pi / 2, endAngle: quizRate * CGFloat.pi, clockwise: true)
+        let bezierPath = UIBezierPath(arcCenter: arcCenter, radius: radius, startAngle: -0.5 * CGFloat.pi, endAngle: 1.5 * CGFloat.pi, clockwise: true)
         calayer.path = bezierPath.cgPath
         calayer.strokeColor = UIColor.red.cgColor
         calayer.fillColor = UIColor.clear.cgColor
@@ -95,8 +95,8 @@ extension ResultView {
         calayer.lineCap = .round
         
         let caAnimation = CABasicAnimation(keyPath: "strokeEnd")
-        caAnimation.toValue = 1
         caAnimation.fromValue = 0
+        caAnimation.toValue = quizRate
         caAnimation.duration = duration
         caAnimation.fillMode = .forwards
         caAnimation.isRemovedOnCompletion = false

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/ResultView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/ResultView.swift
@@ -1,0 +1,120 @@
+//
+//  ResultView.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/25.
+//
+
+import UIKit
+
+final class ResultView: UIView {
+    
+    private let correctRateLabel: UILabel = {
+        let label = UILabel()
+        label.text = "50"
+        label.font = .systemFont(ofSize: 40, weight: .bold)
+        label.textColor = .black
+        return label
+    }()
+    private let allCountLabel: UILabel = {
+        let label = UILabel()
+        label.text = "2 / 4"
+        label.font = .systemFont(ofSize: 24, weight: .regular)
+        label.textColor = .black
+        return label
+    }()
+    private var count: Int = 0
+    private let endValue: Int = 50
+    private let duration: CGFloat = 2
+    private let quizRate: CGFloat = 0.5
+    private var displayLink: CADisplayLink?
+
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension ResultView {
+    func setup() {
+        addViews()
+        autoLayoutSetup()
+    }
+    func addViews() {
+        addSubview(correctRateLabel)
+        addSubview(allCountLabel)
+    }
+    
+    func autoLayoutSetup() {
+        correctRateLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.bottom.equalTo(snp.centerY)
+        }
+        allCountLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(correctRateLabel.snp.bottom).offset(12)
+        }
+    }
+}
+
+//MARK: Animation
+extension ResultView {
+    
+    func progressBarSetupAnimation() {
+        layoutIfNeeded()
+        
+        let bezierPathTest = UIBezierPath(ovalIn: bounds)
+        let progressBar = CAShapeLayer()
+        progressBar.path = bezierPathTest.cgPath
+        progressBar.fillColor = UIColor.clear.cgColor
+        progressBar.strokeColor = UIColor.red.withAlphaComponent(0.3).cgColor
+        progressBar.lineWidth = 3
+        layer.addSublayer(progressBar)
+        
+        let arcCenter = CGPoint(x: bounds.width/2, y: bounds.height/2)
+        let radius = bounds.width/2
+        let calayer = CAShapeLayer()
+        let bezierPath = UIBezierPath(arcCenter: arcCenter, radius: radius, startAngle: -.pi / 2, endAngle: quizRate * CGFloat.pi, clockwise: true)
+        calayer.path = bezierPath.cgPath
+        calayer.strokeColor = UIColor.red.cgColor
+        calayer.fillColor = UIColor.clear.cgColor
+        calayer.lineWidth = 8
+        calayer.lineCap = .round
+        
+        let caAnimation = CABasicAnimation(keyPath: "strokeEnd")
+        caAnimation.toValue = 1
+        caAnimation.fromValue = 0
+        caAnimation.duration = duration
+        caAnimation.fillMode = .forwards
+        caAnimation.isRemovedOnCompletion = false
+        calayer.add(caAnimation, forKey: nil)
+        
+        startDisplayLink()
+        
+        layer.addSublayer(calayer)
+    }
+    
+    private func startDisplayLink() {
+        stopDisplayLink()
+        displayLink = CADisplayLink(target: self, selector: #selector(countLabelUpdate))
+        displayLink?.preferredFramesPerSecond = 100
+        displayLink?.add(to: .main, forMode: .default)
+    }
+    
+    private func stopDisplayLink() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+    
+    @objc private func countLabelUpdate() {
+        count += 1
+        if count >= endValue { stopDisplayLink() }
+        correctRateLabel.text = "\(count)"
+    }
+}

--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/View/ResultView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/View/ResultView.swift
@@ -11,27 +11,34 @@ final class ResultView: UIView {
     
     private let correctRateLabel: UILabel = {
         let label = UILabel()
-        label.text = "50"
         label.font = .systemFont(ofSize: 40, weight: .bold)
         label.textColor = .black
         return label
     }()
     private let allCountLabel: UILabel = {
         let label = UILabel()
-        label.text = "2 / 4"
         label.font = .systemFont(ofSize: 24, weight: .regular)
         label.textColor = .black
         return label
     }()
     private var count: Int = 0
-    private let endValue: Int = 50
-    private let duration: CGFloat = 2
-    private let quizRate: CGFloat = 0.5
+    private let endValue: Double
+    private let startValue: Double = 0
+    private let duration: CGFloat = 1
+    private let quizRate: CGFloat
     private var displayLink: CADisplayLink?
+    private var animationStartDate: Date? = nil
 
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(correctRate: CGFloat, allWordCount: Int, isMemorizeCount: Int) {
+        quizRate = correctRate
+        endValue = correctRate * 100
+        
+        self.correctRateLabel.text = "0"
+        self.allCountLabel.text = "\(isMemorizeCount) / \(allWordCount)"
+        
+        super.init(frame: .zero)
+        
         setup()
     }
     
@@ -103,7 +110,7 @@ extension ResultView {
     private func startDisplayLink() {
         stopDisplayLink()
         displayLink = CADisplayLink(target: self, selector: #selector(countLabelUpdate))
-        displayLink?.preferredFramesPerSecond = 100
+        animationStartDate = Date()
         displayLink?.add(to: .main, forMode: .default)
     }
     
@@ -113,8 +120,18 @@ extension ResultView {
     }
     
     @objc private func countLabelUpdate() {
-        count += 1
-        if count >= endValue { stopDisplayLink() }
+        guard let animationStartDate else { return }
+        let now = Date()
+        let time = now.timeIntervalSince(animationStartDate)
+        
+        if time > duration {
+            stopDisplayLink()
+            correctRateLabel.text = "\(Int(endValue))"
+            return
+        }
+        let percentage = time / duration
+        let value = percentage * (endValue - startValue)
+        count = Int(value)
         correctRateLabel.text = "\(count)"
     }
 }

--- a/oewoboka/oewoboka/Scenes/QuizPage/Model/Vocabulary.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/Model/Vocabulary.swift
@@ -1,0 +1,14 @@
+//
+//  vocabulary.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/25.
+//
+
+import Foundation
+
+struct Vocabulary {
+    let id: UUID
+    let context: String
+    let words: [Word]
+}

--- a/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct Word {
     let id: UUID
+    let vocabularyTitle: String
     let english: String
     let korea: String
     var isMemorize: Bool

--- a/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
@@ -11,5 +11,5 @@ struct Word {
     let id: UUID
     let english: String
     let korea: String
-    let isMemorize: Bool
+    var isMemorize: Bool
 }

--- a/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
@@ -13,4 +13,5 @@ struct Word {
     let english: String
     let korea: String
     var isMemorize: Bool
+    var isBookmark: Bool
 }

--- a/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/Model/Word.swift
@@ -1,0 +1,15 @@
+//
+//  Word.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/25.
+//
+
+import Foundation
+
+struct Word {
+    let id: UUID
+    let english: String
+    let korea: String
+    let isMemorize: Bool
+}

--- a/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
@@ -16,7 +16,7 @@ final class QuizViewController: UIViewController {
     private let margin: CGFloat = 24
     private var currentIndex: Int = 0
     
-    let vocablularyList: Vocabulary = Vocabulary(id: UUID(), context: "Title", words: [Word(id: UUID(), english: "english", korea: "한국어", isMemorize: false),Word(id: UUID(), english: "english2", korea: "한국어2", isMemorize: false), Word(id: UUID(), english: "english3", korea: "한국어3", isMemorize: false)])
+    let vocablularyList: Vocabulary = Vocabulary(id: UUID(), context: "Title", words: [Word(id: UUID(), vocabularyTitle: "Test", english: "english", korea: "한국어", isMemorize: false),Word(id: UUID(), vocabularyTitle: "Test", english: "english2", korea: "한국어2", isMemorize: false), Word(id: UUID(), vocabularyTitle: "Test", english: "english3", korea: "한국어3", isMemorize: false)])
     private let quizType: QuizType
     private var quizResultWords: [Word] = []
     private var words: [Word] = []

--- a/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
@@ -16,7 +16,7 @@ final class QuizViewController: UIViewController {
     private let margin: CGFloat = 24
     private var currentIndex: Int = 0
     
-    let vocablularyList: Vocabulary = Vocabulary(id: UUID(), context: "Title", words: [Word(id: UUID(), vocabularyTitle: "Test", english: "english", korea: "한국어", isMemorize: false),Word(id: UUID(), vocabularyTitle: "Test", english: "english2", korea: "한국어2", isMemorize: false), Word(id: UUID(), vocabularyTitle: "Test", english: "english3", korea: "한국어3", isMemorize: false)])
+    let vocablularyList: Vocabulary = Vocabulary(id: UUID(), context: "Title", words: [Word(id: UUID(), vocabularyTitle: "Test", english: "english", korea: "한국어", isMemorize: false, isBookmark: false),Word(id: UUID(), vocabularyTitle: "Test", english: "english2", korea: "한국어2", isMemorize: false, isBookmark: false), Word(id: UUID(), vocabularyTitle: "Test", english: "english3", korea: "한국어3", isMemorize: false, isBookmark: false)])
     private let quizType: QuizType
     private var quizResultWords: [Word] = []
     private var words: [Word] = []

--- a/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
@@ -139,8 +139,8 @@ private extension QuizViewController {
     @objc func cardMove(sender: UIPanGestureRecognizer) {
         guard let moveView = sender.view else { return }
         let point = sender.translation(in: view)
-        moveView.center = CGPoint(x: view.center.x + point.x, y: moveView.center.y)
-        
+        moveView.center = CGPoint(x: view.center.x + point.x, y: view.center.y + point.y)
+                
         var word = vocablularyList.words[currentIndex]
         
         if sender.state == .ended {

--- a/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/QuizViewController.swift
@@ -8,22 +8,72 @@
 import Foundation
 import UIKit
 
-final class QuizeViewController: UIViewController {
+final class QuizViewController: UIViewController {
+    
+    private let frontCardView: CardView = CardView()
+    private let backgroundCardView: CardView = CardView()
+    private let quizControlView: QuizControlStackView = QuizControlStackView(buttonSize: CGSize(width: 52.0, height: 52.0))
+    private let margin: CGFloat = 24
+    let vocablularyList: [Vocabulary] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setup()
         // Do any additional setup after loading the view.
     }
     
+}
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+private extension QuizViewController {
+    func setup() {
+        addViews()
+        navigationSetup()
+        cardViewSetup()
+        autoLayoutSetup()
     }
-    */
     
+    func addViews() {
+        view.addSubview(backgroundCardView)
+        view.addSubview(frontCardView)
+        view.addSubview(quizControlView)
+    }
+    
+    func navigationSetup() {
+        title = vocablularyList.first?.context
+    }
+    
+    func cardViewSetup() {
+//        guard let vocabulary = vocablularyList.first,
+//              let word = vocabulary.words.first else { return }
+//        cardView.englishLabel.text = word.english
+//        cardView.koreaLabel.text = word.korea
+        frontCardView.englishLabel.text = "영어"
+        frontCardView.koreaLabel.text = "한글"
+        frontCardView.layer.borderWidth = 1
+        frontCardView.layer.borderColor = UIColor.black.cgColor
+        frontCardView.layer.cornerRadius = 10
+        frontCardView.layer.masksToBounds = true
+        
+        backgroundCardView.englishLabel.text = "영어2"
+        backgroundCardView.koreaLabel.text = "한글2"
+        backgroundCardView.layer.borderWidth = 1
+        backgroundCardView.layer.borderColor = UIColor.black.cgColor
+        backgroundCardView.layer.cornerRadius = 10
+        backgroundCardView.layer.masksToBounds = true
+    }
+    
+    func autoLayoutSetup() {
+        let safeArea = view.safeAreaLayoutGuide
+        frontCardView.snp.makeConstraints { make in
+            make.top.left.right.equalTo(safeArea).inset(margin)
+        }
+        backgroundCardView.snp.makeConstraints { make in
+            make.edges.equalTo(frontCardView)
+        }
+        quizControlView.snp.makeConstraints { make in
+            make.top.equalTo(frontCardView.snp.bottom).offset(margin)
+            make.height.equalTo(52)
+            make.left.right.bottom.equalTo(safeArea).inset(margin)
+        }
+    }
 }

--- a/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
@@ -9,6 +9,13 @@ import UIKit
 import SnapKit
 
 final class CardView: UIView {
+    let topLineStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .equalSpacing
+        return stackView
+    }()
     let wordCountLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .bold)
@@ -18,7 +25,7 @@ final class CardView: UIView {
     private let cardStateStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.alignment = .center
+        stackView.alignment = .fill
         stackView.distribution = .fillEqually
         stackView.spacing = 12
         return stackView
@@ -32,9 +39,12 @@ final class CardView: UIView {
     }()
     private let stateButton: UIButton = {
         let button = UIButton()
-        button.setTitle("?", for: .normal)
-        button.setTitle("!", for: .selected)
-        button.setTitleColor(.black, for: .normal)
+        let contentVerticalInset: CGFloat = 3
+        let contentHorzontalInset: CGFloat = contentVerticalInset * 2
+        button.contentEdgeInsets = UIEdgeInsets(top: contentVerticalInset, left: contentHorzontalInset, bottom: contentVerticalInset, right: contentHorzontalInset)
+        button.setImage(UIImage(systemName: "questionmark"), for: .normal)
+        button.setImage(UIImage(systemName: "exclamationmark"), for: .selected)
+        button.tintColor = .black
         return button
     }()
     private let wordStackView: UIStackView = {
@@ -85,8 +95,9 @@ private extension CardView {
     }
     
     func addViews() {
-        addSubview(wordCountLabel)
-        addSubview(cardStateStackView)
+        addSubview(topLineStackView)
+        topLineStackView.addArrangedSubview(wordCountLabel)
+        topLineStackView.addArrangedSubview(cardStateStackView)
         cardStateStackView.addArrangedSubview(bookMarkButton)
         cardStateStackView.addArrangedSubview(stateButton)
         addSubview(wordStackView)
@@ -95,12 +106,16 @@ private extension CardView {
     }
     
     func autoLayoutSetup() {
-        wordCountLabel.snp.makeConstraints { make in
-            make.top.left.equalToSuperview().inset(inset)
+        topLineStackView.snp.makeConstraints { make in
+            make.top.left.right.equalToSuperview().inset(inset)
         }
-        cardStateStackView.snp.makeConstraints { make in
-            make.top.right.equalToSuperview().inset(inset)
+        
+        let stateButtonWidthSize = 26
+        
+        stateButton.snp.makeConstraints { make in
+            make.width.equalTo(stateButtonWidthSize)
         }
+
         wordStackView.snp.makeConstraints { make in
             make.center.equalToSuperview()
         }

--- a/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 
 final class CardView: UIView {
-    private let wordCountLabel: UILabel = {
+    let wordCountLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .bold)
         label.textColor = .lightGray

--- a/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
@@ -1,0 +1,121 @@
+//
+//  CardView.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/25.
+//
+
+import UIKit
+import SnapKit
+
+final class CardView: UIView {
+    private let wordCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.textColor = .lightGray
+        return label
+    }()
+    private let cardStateStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.distribution = .fillEqually
+        stackView.spacing = 12
+        return stackView
+    }()
+    private let bookMarkButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundImage(UIImage(systemName: "bookmark"), for: .normal)
+        button.setBackgroundImage(UIImage(systemName: "bookmark.fill"), for: .selected)
+        button.tintColor = .lightGray
+        return button
+    }()
+    private let stateButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("?", for: .normal)
+        button.setTitle("!", for: .selected)
+        button.setTitleColor(.black, for: .normal)
+        return button
+    }()
+    private let wordStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .fillEqually
+        stackView.spacing = 12
+        return stackView
+    }()
+    let englishLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.textColor = .black
+        return label
+    }()
+    let koreaLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 18, weight: .regular)
+        label.textColor = .black
+        return label
+    }()
+    
+    private let inset: CGFloat = 24
+
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension CardView {
+    func setup() {
+        backgroundColor = .white
+        addViews()
+        autoLayoutSetup()
+        countLabelSetup()
+        buttonSetup()
+    }
+    
+    func addViews() {
+        addSubview(wordCountLabel)
+        addSubview(cardStateStackView)
+        cardStateStackView.addArrangedSubview(bookMarkButton)
+        cardStateStackView.addArrangedSubview(stateButton)
+        addSubview(wordStackView)
+        wordStackView.addArrangedSubview(englishLabel)
+        wordStackView.addArrangedSubview(koreaLabel)
+    }
+    
+    func autoLayoutSetup() {
+        wordCountLabel.snp.makeConstraints { make in
+            make.top.left.equalToSuperview().inset(inset)
+        }
+        cardStateStackView.snp.makeConstraints { make in
+            make.top.right.equalToSuperview().inset(inset)
+        }
+        wordStackView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+        }
+    }
+    
+    func buttonSetup() {
+        bookMarkButton.addTarget(self, action: #selector(bookMarkClick), for: .touchUpInside)
+        stateButton.addTarget(self, action: #selector(stateButtonClick), for: .touchUpInside)
+    }
+    
+    func countLabelSetup() {
+        wordCountLabel.text = "1/6"
+    }
+    
+    @objc func bookMarkClick() {
+        bookMarkButton.isSelected.toggle()
+    }
+    
+    @objc func stateButtonClick() {
+        stateButton.isSelected.toggle()
+    }
+}

--- a/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/View/CardView.swift
@@ -59,6 +59,11 @@ final class CardView: UIView {
     }()
     
     private let inset: CGFloat = 24
+    var quizType: QuizType = .training {
+        didSet {
+            quizTypeSetup()
+        }
+    }
 
     init() {
         super.init(frame: .zero)
@@ -76,7 +81,6 @@ private extension CardView {
         backgroundColor = .white
         addViews()
         autoLayoutSetup()
-        countLabelSetup()
         buttonSetup()
     }
     
@@ -102,13 +106,22 @@ private extension CardView {
         }
     }
     
+    func quizTypeSetup() {
+        switch quizType {
+        case .training:
+            break
+        case .wordDictation:
+            englishLabel.isHidden = true
+        case .meanDictation:
+            koreaLabel.isHidden = true
+        case .test:
+            print("test")
+        }
+    }
+    
     func buttonSetup() {
         bookMarkButton.addTarget(self, action: #selector(bookMarkClick), for: .touchUpInside)
         stateButton.addTarget(self, action: #selector(stateButtonClick), for: .touchUpInside)
-    }
-    
-    func countLabelSetup() {
-        wordCountLabel.text = "1/6"
     }
     
     @objc func bookMarkClick() {

--- a/oewoboka/oewoboka/Scenes/QuizPage/View/QuizControlStackView.swift
+++ b/oewoboka/oewoboka/Scenes/QuizPage/View/QuizControlStackView.swift
@@ -1,0 +1,97 @@
+//
+//  QuizControlStackView.swift
+//  oewoboka
+//
+//  Created by 김도현 on 2023/09/25.
+//
+
+import UIKit
+
+final class QuizControlStackView: UIStackView {
+    private let reloadButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundImage(UIImage(systemName: "arrow.counterclockwise"), for: .normal)
+        button.tintColor = .black
+        button.layer.borderColor = UIColor.black.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = 5
+        return button
+    }()
+    private let xButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = .red
+        button.layer.borderColor = UIColor.systemRed.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = 5
+        return button
+    }()
+    private let oButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundImage(UIImage(systemName: "circle"), for: .normal)
+        button.tintColor = .systemBlue
+        button.layer.borderColor = UIColor.systemBlue.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = 5
+        return button
+    }()
+    private let showButton: UIButton = {
+        let button = UIButton()
+        button.setBackgroundImage(UIImage(systemName: "eye"), for: .normal)
+        button.setBackgroundImage(UIImage(systemName: "eye.slash"), for: .selected)
+        button.tintColor = .black
+        button.layer.borderColor = UIColor.black.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = 5
+        return button
+    }()
+    private let mainButtonSize: CGSize
+
+
+    init(buttonSize: CGSize) {
+        self.mainButtonSize = buttonSize
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+private extension QuizControlStackView {
+    func setup() {
+        initSetup()
+        addViews()
+        autoLayoutSetup()
+    }
+    
+    func initSetup() {
+        axis = .horizontal
+        alignment = .center
+        distribution = .equalSpacing
+    }
+    
+    func addViews() {
+        addArrangedSubview(reloadButton)
+        addArrangedSubview(xButton)
+        addArrangedSubview(oButton)
+        addArrangedSubview(showButton)
+    }
+    
+    func autoLayoutSetup() {
+        xButton.snp.makeConstraints { make in
+            make.height.equalTo(mainButtonSize.height)
+            make.width.equalTo(mainButtonSize.width)
+        }
+        oButton.snp.makeConstraints { make in
+            make.height.width.equalTo(xButton)
+        }
+        reloadButton.snp.makeConstraints { make in
+            make.height.width.equalTo(xButton).dividedBy(1.5)
+        }
+        showButton.snp.makeConstraints { make in
+            make.height.width.equalTo(xButton).dividedBy(1.5)
+        }
+    }
+}

--- a/oewoboka/oewoboka/View/DefaultButton.swift
+++ b/oewoboka/oewoboka/View/DefaultButton.swift
@@ -84,7 +84,7 @@ extension DefaultButton {
         contentEdgeInsets = UIEdgeInsets(top: verticalPadding, left: horizontalPadding, bottom: verticalPadding, right: horizontalPadding)
         switch type {
         case .center:
-            let leftEdgeInset = bounds.width/2 - (titleLabel?.bounds.width ?? 0)
+            let leftEdgeInset = bounds.width/2 - (titleLabel?.bounds.width ?? 0)/2 - (imageView?.bounds.width ?? 0)  - spacing
             titleEdgeInsets.left = leftEdgeInset
         case .left:
             titleEdgeInsets.left = spacing

--- a/oewoboka/oewoboka/View/DefaultButton.swift
+++ b/oewoboka/oewoboka/View/DefaultButton.swift
@@ -41,13 +41,14 @@ final class DefaultButton: UIButton {
     }
     
     var verticalPadding: CGFloat = 4
-    var horizontalPadding: CGFloat = 8
+    var horizontalPadding: CGFloat = 12
     var spacing: CGFloat = 8
     
     // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        imageViewSetup()
         setTitle()
         makeRound()
         makeBorder()
@@ -60,6 +61,7 @@ final class DefaultButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         typeSetup()
+        print(center, titleLabel?.center)
     }
     
 }
@@ -67,6 +69,9 @@ final class DefaultButton: UIButton {
 // MARK: - InitUI
 extension DefaultButton {
         
+    private func imageViewSetup() {
+        imageView?.contentMode = .scaleAspectFill
+    }
     private func setTitle() {
         titleLabel?.font = Typography.body1.font
         setTitleColor(UIColor.black, for: .normal)
@@ -84,7 +89,8 @@ extension DefaultButton {
         contentEdgeInsets = UIEdgeInsets(top: verticalPadding, left: horizontalPadding, bottom: verticalPadding, right: horizontalPadding)
         switch type {
         case .center:
-            let leftEdgeInset = bounds.width/2 - (titleLabel?.bounds.width ?? 0)/2 - (imageView?.bounds.width ?? 0)  - spacing
+            let leftEdgeInset = bounds.width/2 - (titleLabel?.bounds.width ?? 0)/2 - (imageView?.bounds.width ?? 0) - horizontalPadding
+            print(leftEdgeInset)
             titleEdgeInsets.left = leftEdgeInset
         case .left:
             titleEdgeInsets.left = spacing

--- a/oewoboka/oewoboka/View/DefaultButton.swift
+++ b/oewoboka/oewoboka/View/DefaultButton.swift
@@ -61,7 +61,6 @@ final class DefaultButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         typeSetup()
-        print(center, titleLabel?.center)
     }
     
 }
@@ -90,7 +89,6 @@ extension DefaultButton {
         switch type {
         case .center:
             let leftEdgeInset = bounds.width/2 - (titleLabel?.bounds.width ?? 0)/2 - (imageView?.bounds.width ?? 0) - horizontalPadding
-            print(leftEdgeInset)
             titleEdgeInsets.left = leftEdgeInset
         case .left:
             titleEdgeInsets.left = spacing


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
퀴즈 화면에 있던 진행도 표시 UI를 다른 테이블뷰에서도 사용할 수 있도록 변경
최상위 View 폴더에 CircleProgressBar 클래스로 변경

type : number, percent 두가지 타입이 존재함
number: 숫자로만 나오고, 밑에 성공과 실패한 갯수가 표시됨
<img width="58" alt="스크린샷 2023-10-02 오후 6 34 23" src="https://github.com/Ca2sta/oewoboka/assets/71269216/2854372a-9a64-45e3-98be-cd02e4dba9ce">

precent: 숫자에 "%"가 표시됨, 숫자가 가운데로 이동
<img width="58" alt="스크린샷 2023-10-02 오후 6 33 39" src="https://github.com/Ca2sta/oewoboka/assets/71269216/92cf3a0e-3d15-419a-a2e6-49e18a8232ea">

폰트, 테두리 굵기, 프로그래스바 라인 굵기, 배경색 변경가능
## Issue
#19