### PR TITLE
[BUG] 퀴즈 결과 화면에서 뒤로가기시 기능 선택 화면이 아니라 퀴즈화면으로 넘어가는 버그 수정

### DIFF
--- a/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
+++ b/oewoboka/oewoboka/Scenes/QuizCompletePage/QuizCompleteViewController.swift
@@ -96,7 +96,7 @@ private extension QuizCompleteViewController {
     }
     
     @objc func backButtonClick() {
-        navigationController?.popToRootViewController(animated: true)
+        dismiss(animated: true)
     }
 }
 


### PR DESCRIPTION
<!--
코드를 변경한 경우 어떤 부분을 변경했는지 구체적으로 작성
스크린샷의 경우 UI의 변경이 있었거나 UI를 수정한 경우 작성하고 아니면 비워두기
-->
## 작업내용
퀴즈 결과 화면에서 뒤로가기시 기능 선택 화면이 아니라 퀴즈화면으로 넘어가는 버그 수정
## 작업내용 (이미지)
![Simulator Screen Recording - iPhone 14 Pro - 2023-10-05 at 18 00 40](https://github.com/Ca2sta/oewoboka/assets/71269216/f5aad9dd-0813-42e7-92c3-fd62f49340ea)
